### PR TITLE
Improve permanent/temporary redirect handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rfetch (0.1.5)
+    rfetch (0.1.6)
       faraday
       faraday-httpclient (~> 2.0)
       nokogiri
@@ -11,12 +11,12 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    faraday (2.4.0)
-      faraday-net_http (~> 2.0)
+    faraday (2.5.2)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-httpclient (2.0.1)
       httpclient (>= 2.2)
-    faraday-net_http (2.1.0)
+    faraday-net_http (3.0.0)
     httpclient (2.8.3)
     json (2.6.2)
     nokogiri (1.13.8-x86_64-darwin)

--- a/lib/rfetch/version.rb
+++ b/lib/rfetch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RFetch
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/rfetch_spec.rb
+++ b/spec/rfetch_spec.rb
@@ -27,8 +27,110 @@ RSpec.describe RFetch do
     end
 
     pending "raises an exception if the specified URL is not found"
-    pending "follows redirects and returns the target URL in the result"
-    pending "follows multiple redirects and returns the last URL in the result"
+
+    it "follows a permanent redirect and returns the target URL in the result" do
+      stubs.get("https://old.com") do
+        [
+          301,
+          { "Location": "https://new.com" }
+        ]
+      end
+
+      stubs.get("https://new.com") do
+        [
+          200,
+          { "Content-Type": "text/plain" },
+          "Contents of the new page"
+        ]
+      end
+
+      result = RFetch.get("https://old.com")
+
+      expect(result).to eq(RFetch::Result.new("https://new.com", 200, "text/plain", "Contents of the new page"))
+    end
+
+    it "follows multiple permanent redirects and returns the last URL in the result" do
+      stubs.get("https://old.com") do
+        [
+          301,
+          { "Location": "https://middle.com" }
+        ]
+      end
+
+      stubs.get("https://middle.com") do
+        [
+          301,
+          { "Location": "https://new.com" }
+        ]
+      end
+
+      stubs.get("https://new.com") do
+        [
+          200,
+          { "Content-Type": "text/plain" },
+          "Contents of the new page"
+        ]
+      end
+
+      result = RFetch.get("https://old.com")
+
+      expect(result).to eq(RFetch::Result.new("https://new.com", 200, "text/plain", "Contents of the new page"))
+    end
+
+    it "follows a permanent redirect followed by a temporary redirect, returning the URL from the permanent redirect" do
+      stubs.get("https://old.com") do
+        [
+          301,
+          { "Location": "https://permanent.com" }
+        ]
+      end
+
+      stubs.get("https://permanent.com") do
+        [
+          302,
+          { "Location": "https://temporary.com" }
+        ]
+      end
+
+      stubs.get("https://temporary.com") do
+        [
+          200,
+          { "Content-Type": "text/plain" },
+          "This is a temporary page"
+        ]
+      end
+
+      result = RFetch.get("https://old.com")
+
+      expect(result).to eq(RFetch::Result.new("https://permanent.com", 200, "text/plain", "This is a temporary page"))
+    end
+
+    it "returns the URL of the last permanent redirect that came before any temporary redirects" do
+      stubs.get("https://old.com") do
+        [301, { "Location": "https://permanent.com" }]
+      end
+
+      stubs.get("https://permanent.com") do
+        [302, { "Location": "https://temporary.com" }]
+      end
+
+      stubs.get("https://temporary.com") do
+        [301, { "Location": "https://permanent-redirect-for-temporary.com" }]
+      end
+
+      stubs.get("https://permanent-redirect-for-temporary.com") do
+        [
+          200,
+          { "Content-Type": "text/plain" },
+          "Resulting page"
+        ]
+      end
+
+      result = RFetch.get("https://old.com")
+
+      expect(result).to eq(RFetch::Result.new("https://permanent.com", 200, "text/plain", "Resulting page"))
+    end
+
     pending "detects redirect loops"
     pending "handles redirects to a path only (without a host in Location)"
   end


### PR DESCRIPTION
When returning the URL in the result of `RFetch.get` we only want this to take account of _permanent_ redirects. 

We still follow _temporary_ redirects in order to arrive at the eventual content to return, but the URL returned should be either

 - the originally requested URL (when there are no redirects), or
 - the end of a chain of permanent redirects before encountering any temporary redirects

i.e. get A, permanent redirect to B, temporary redirect to C returns the URL of B and the content from C.