### PR TITLE
Increase default timeout and add option to specify timeout

### DIFF
--- a/lib/rfetch.rb
+++ b/lib/rfetch.rb
@@ -42,9 +42,9 @@ module RFetch
     end
   end
 
-  def self.get(url_requested)
+  def self.get(url_requested, options = {})
     url, response = following_redirects(url_requested) do |url|
-      connection.get(url) { |req| req.options.timeout = 5 }
+      connection.get(url) { |req| req.options.timeout = options[:timeout] || 10 }
     end
 
     raise RequestError.new(response.status, response.reason_phrase) unless response.success?

--- a/lib/rfetch/version.rb
+++ b/lib/rfetch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RFetch
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
allow timeout to be specified as part of call to `RFetch.get`
